### PR TITLE
検索結果が10件未満の時に、リストが正常に表示されない件についての修正

### DIFF
--- a/.idea/libraries/Dart_Packages.xml
+++ b/.idea/libraries/Dart_Packages.xml
@@ -268,6 +268,13 @@
             </list>
           </value>
         </entry>
+        <entry key="recipe_app">
+          <value>
+            <list>
+              <option value="$PROJECT_DIR$/../lib" />
+            </list>
+          </value>
+        </entry>
         <entry key="sky_engine">
           <value>
             <list>
@@ -366,6 +373,13 @@
             </list>
           </value>
         </entry>
+        <entry key="youtube_player_flutter">
+          <value>
+            <list>
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/youtube_player_flutter-8.0.0/lib" />
+            </list>
+          </value>
+        </entry>
       </option>
     </properties>
     <CLASSES>
@@ -386,6 +400,7 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/firebase_core-1.13.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/firebase_core_platform_interface-4.2.5/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/firebase_core_web-1.6.1/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/flutter_inappwebview-5.3.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/flutter_lints-1.0.4/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/flutter_screenutil-5.3.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/google_sign_in-5.2.4/lib" />
@@ -417,10 +432,12 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/webview_flutter_platform_interface-1.8.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/webview_flutter_wkwebview-2.7.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/youtube_api-1.0.4/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/youtube_player_flutter-8.0.0/lib" />
       <root url="file://$USER_HOME$/Developer/flutter/bin/cache/pkg/sky_engine/lib" />
       <root url="file://$USER_HOME$/Developer/flutter/packages/flutter/lib" />
       <root url="file://$USER_HOME$/Developer/flutter/packages/flutter_test/lib" />
       <root url="file://$USER_HOME$/Developer/flutter/packages/flutter_web_plugins/lib" />
+      <root url="file://$PROJECT_DIR$/../lib" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/lib/bottom_navigation_bar_pages/recipes/recipe_page_model.dart
+++ b/lib/bottom_navigation_bar_pages/recipes/recipe_page_model.dart
@@ -10,7 +10,6 @@ class RecipePageModel extends ChangeNotifier {
 
   Future<void> callAPI() async {
     String query = TextData.queryKeyword;
-    // TODO queryが10文字以上じゃないとエラーが出る問題は調査中
     _videoResult = await _youtube.search(
       query,
       order: TextData.relevance,

--- a/lib/text_data.dart
+++ b/lib/text_data.dart
@@ -197,7 +197,7 @@ class TextData {
 
   static const String youtubeChannelID = "UCb0jMRgVdSxanToDdNobhjA";
   static const String youtubeV3APIKey = "AIzaSyAvdhPss_s6AoxEjmZumJxS8-5HExH9J2Q";
-  static const String queryKeyword = 'たまねぎを使ったレシピ';
+  static const String queryKeyword = 'たまねぎ';
   static const String relevance = 'relevance';
   static const String any = 'any';
 }

--- a/lib/youtube_api.dart
+++ b/lib/youtube_api.dart
@@ -112,7 +112,9 @@ class YoutubeAPI {
     List<YouTubeVideo>? result = [];
     if (jsonData == null) return [];
     nextPageToken = jsonData['nextPageToken'];
-    api!.setNextPageToken(nextPageToken!);
+    if(nextPageToken != null) {
+      api!.setNextPageToken(nextPageToken!);
+    }
     int total = jsonData['pageInfo']['totalResults'] <
             jsonData['pageInfo']['resultsPerPage']
         ? jsonData['pageInfo']['totalResults']


### PR DESCRIPTION
## 概要
- 検索結果が10件未満の時、レシピページのリスト一覧が1件も表示されない問題について修正を行いました。
## 確認方法
- 検索結果が10件未満になるキーワード（たまねぎ）をqueryKeywordに代入しておきます。
- 検索結果が10件未満でも正常にリスト表示されていることを確認します。（今回は8件）

https://user-images.githubusercontent.com/83540648/160047317-f6578ec6-083d-4c1e-97f7-cf0c86fa2647.mov


